### PR TITLE
Added optional custom nginx config support

### DIFF
--- a/proxy-manager/config.json
+++ b/proxy-manager/config.json
@@ -20,7 +20,7 @@
   "boot": "auto",
   "hassio_api": true,
   "hassio_role": "default",
-  "map": ["ssl:rw"],
+  "map": ["ssl:rw","share:ro"],
   "options": {},
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"

--- a/proxy-manager/rootfs/etc/cont-init.d/npm.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/npm.sh
@@ -90,6 +90,12 @@ fi
 
 ln -sf /ssl/nginxproxymanager /etc/letsencrypt
 
+if bashio::fs.directory_exists "/share/npm"; then
+    bashio::log.info "Adding link to /share/npm for custom config files"
+    rm -f /data/nginx/custom || true
+    ln -sf /share/npm /data/nginx/custom
+fi
+
 # NGinx needs this file to be able to start.
 # It will not continously log into it.
 mkdir -p /var/lib/nginx/logs


### PR DESCRIPTION
# Proposed Changes

Give advanced users more flexibility by allowing them to include custom config files at different locations in the nginx configuration. Links in files from /share/npm (if the directory exists)

`/share/npm/root.conf`: Included at the very end of nginx.conf
`/share/npm/http.conf`: Included at the end of the main http block
`/share/npm/server_proxy.conf`: Included at the end of every proxy server block
`/share/npm/server_redirect.conf`: Included at the end of every redirection server block

## Related Issues

jc21/nginx-proxy-manager#178

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/